### PR TITLE
chore: 型定義を type に統一し ESLint で強制 (closes #20)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals"],
+  "plugins": ["@typescript-eslint"],
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "@typescript-eslint/consistent-type-definitions": ["error", "type"]
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ db:migrate   npx supabase migration up
 
 - 用語は `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` の正本に従う（例: `CoffeeEvaluation` ✓ / `CoffeeReview` ✗）。
 - Clean Architecture 層依存: `domain ← application ← infrastructure / presentation`。`lib/domain/**` は外側を import しない。
+- 型定義は `type` を使う（`interface` 禁止 / lint で強制。詳細: `@docs/decisions/2026-04-29-type-vs-interface.md`）。
 - UI 文言は日本語、コードは英語。
 
 ## Workflow

--- a/app/(app)/coffee/_components/shared/public-badge.tsx
+++ b/app/(app)/coffee/_components/shared/public-badge.tsx
@@ -15,7 +15,7 @@
 
 import { getVisibilityText, VISIBILITY_BADGE_STYLES } from '@/lib/constants/visibility'
 
-interface PublicBadgeProps {
+type PublicBadgeProps = {
   isPublic: boolean
   className?: string
 }

--- a/app/(app)/coffee/_components/shared/public-toggle.tsx
+++ b/app/(app)/coffee/_components/shared/public-toggle.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useId } from 'react'
 
-interface PublicToggleProps {
+type PublicToggleProps = {
   defaultChecked: boolean
   name: string
 }

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,11 +1,11 @@
 import React, { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+type ButtonProps = {
   children: ReactNode
   variant?: 'primary' | 'secondary'
   fullWidth?: boolean
   loading?: boolean
-}
+} & ButtonHTMLAttributes<HTMLButtonElement>
 
 export function Button({
   children,

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,9 +1,9 @@
 import React, { InputHTMLAttributes } from 'react'
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+type InputProps = {
   label?: string
   error?: string
-}
+} & InputHTMLAttributes<HTMLInputElement>
 
 export function Input({
   label,

--- a/docs/decisions/2026-04-29-type-vs-interface.md
+++ b/docs/decisions/2026-04-29-type-vs-interface.md
@@ -1,0 +1,38 @@
+# 型定義は `type` に統一する
+
+- 日付: 2026-04-29
+- Issue: #20
+
+## 決定
+
+TypeScript の型定義は **`type` のみ使用**し、`interface` は使わない。
+`@typescript-eslint/consistent-type-definitions: ['error', 'type']` で強制する。
+
+## 背景
+
+`type` と `interface` が混在しており（123 vs 42、約 75% が `type`）、命名・拡張・union の表現で揺れていた。
+
+## なぜ `type` か
+
+- 既に大多数 (75%) が `type`。`type` 統一の方が改修コストが小さい。
+- `type` は `interface` の機能を包含する:
+  - 拡張: `type X = A & { foo: string }` (vs `interface X extends A { foo: string }`)
+  - 共用体: `type R = { ok: true } | { ok: false }`（`interface` 不可）
+  - mapped / conditional / utility types
+- ESLint の auto-fix が効くため、ルール導入と一括変換を 1 PR で完結できる。
+
+## 却下した案
+
+- **`interface` 統一**: 共用体が書けず、123 件の置換も大規模。
+- **両方許容 + 命名規約**: ESLint で表現できず、レビューに依存して揺れる。
+- **オブジェクト形は `interface`、union は `type`**: ルールが文脈依存で機械的に enforce できない。
+
+## 影響
+
+- 既存の 42 件の `interface` を `type` に自動変換（`pnpm lint --fix`）。
+- 新規コードは ESLint が違反を error 報告する。
+- `declare module ... { interface ... }` のような型拡張は `.d.ts` で個別に許可（必要時に override コメント）。
+
+## 適用範囲外
+
+- サードパーティの型拡張（例: `@testing-library/jest-dom` が `jest.Matchers` を augment）は `interface` のままで問題ない。これは外部ライブラリの仕様であり、本リポジトリのコードには該当しない。

--- a/lib/actions/coffee.ts
+++ b/lib/actions/coffee.ts
@@ -22,7 +22,7 @@ import type { User } from '@supabase/supabase-js'
  */
 type ActionResponse = { error: string } | void
 
-interface ParsedBeanInfo {
+type ParsedBeanInfo = {
   shop_name: string
   shop_id: string | null
   bean_type: string
@@ -32,7 +32,7 @@ interface ParsedBeanInfo {
   is_public: boolean
 }
 
-interface ParsedRatings {
+type ParsedRatings = {
   acidity: number
   bitterness: number
   aroma: number

--- a/lib/application/coffee-evaluation/dto.ts
+++ b/lib/application/coffee-evaluation/dto.ts
@@ -12,7 +12,7 @@ import type { RatingValue, EvaluationSortOption } from '@/lib/domain'
 /**
  * Input DTO for creating a new coffee evaluation
  */
-export interface CreateEvaluationInput {
+export type CreateEvaluationInput = {
   /** Shop/cafe name (optional) */
   shopName?: string
   /** Shop entity ID (optional) */
@@ -38,7 +38,7 @@ export interface CreateEvaluationInput {
 /**
  * Input DTO for updating an existing coffee evaluation
  */
-export interface UpdateEvaluationInput {
+export type UpdateEvaluationInput = {
   /** Evaluation ID */
   id: string
   /** Shop/cafe name */
@@ -66,7 +66,7 @@ export interface UpdateEvaluationInput {
 /**
  * Query parameters for listing evaluations
  */
-export interface ListEvaluationsQuery {
+export type ListEvaluationsQuery = {
   /** Filter by user ID */
   userId?: string
   /** Filter by public/private status */
@@ -86,7 +86,7 @@ export interface ListEvaluationsQuery {
 /**
  * Output DTO for a coffee evaluation
  */
-export interface EvaluationOutput {
+export type EvaluationOutput = {
   id: string
   userId: string
   shopName: string
@@ -107,9 +107,9 @@ export interface EvaluationOutput {
 /**
  * Output DTO for evaluation with user display name
  */
-export interface EvaluationWithUserOutput extends EvaluationOutput {
+export type EvaluationWithUserOutput = {
   displayName: string | null
-}
+} & EvaluationOutput
 
 /**
  * Use case result type

--- a/lib/application/llm-settings/dto.ts
+++ b/lib/application/llm-settings/dto.ts
@@ -3,7 +3,7 @@ import type { LlmProviderType } from '@/lib/domain/llm-settings'
 /**
  * Input DTO for saving LLM settings (includes plain-text API key from form)
  */
-export interface LlmSettingsInput {
+export type LlmSettingsInput = {
   provider: LlmProviderType
   providerTemplate?: string | null
   apiUrl?: string | null
@@ -15,7 +15,7 @@ export interface LlmSettingsInput {
 /**
  * Output DTO for reading LLM settings (never exposes the raw API key)
  */
-export interface LlmSettingsOutput {
+export type LlmSettingsOutput = {
   provider: LlmProviderType
   providerTemplate: string | null
   apiUrl: string | null

--- a/lib/application/ocr/dto.ts
+++ b/lib/application/ocr/dto.ts
@@ -4,7 +4,7 @@ import type { RoastLevelValue } from '@/lib/mastra/tools/coffee-ocr-tool'
  * OCR extraction output - auto-fill target fields only.
  * shop_latitude/longitude are excluded (handled by geocoding).
  */
-export interface OcrExtractedData {
+export type OcrExtractedData = {
   bean_name: string | null
   bean_type: string | null
   roast_level: RoastLevelValue | null

--- a/lib/application/ports/api-key-encryptor.ts
+++ b/lib/application/ports/api-key-encryptor.ts
@@ -1,4 +1,4 @@
-export interface ApiKeyEncryptor {
+export type ApiKeyEncryptor = {
   encrypt(plaintext: string): string
   decrypt(ciphertext: string): string
 }

--- a/lib/application/ports/llm-model-factory.ts
+++ b/lib/application/ports/llm-model-factory.ts
@@ -12,7 +12,7 @@ export type InlineLlmModelInput = {
   apiKey: string
 }
 
-export interface LlmModelFactory {
+export type LlmModelFactory = {
   createFromUserSettings(
     settings: UserLlmSettings,
     decryptedApiKey: string

--- a/lib/application/ports/ocr-executor.ts
+++ b/lib/application/ports/ocr-executor.ts
@@ -5,7 +5,7 @@ export type OcrExecutionResult =
   | { success: true; data: OcrExtractedData }
   | { error: string }
 
-export interface OcrExecutor {
+export type OcrExecutor = {
   execute(
     model: OcrModel,
     imageBuffer: Buffer,

--- a/lib/application/ports/shop-search-provider.ts
+++ b/lib/application/ports/shop-search-provider.ts
@@ -4,11 +4,11 @@
  * @module lib/application/ports/shop-search-provider
  */
 
-export interface ShopSearchResult {
+export type ShopSearchResult = {
   id: string
   name: string
 }
 
-export interface ShopSearchProvider {
+export type ShopSearchProvider = {
   search(query: string, limit?: number): Promise<ShopSearchResult[]>
 }

--- a/lib/domain/coffee-evaluation/entity.ts
+++ b/lib/domain/coffee-evaluation/entity.ts
@@ -22,7 +22,7 @@ export type CoffeeEvaluationId = string
 /**
  * Input for creating a new CoffeeEvaluation (with ratings)
  */
-export interface CreateCoffeeEvaluationInput {
+export type CreateCoffeeEvaluationInput = {
   userId: string
   shopName?: string
   shopId?: string | null
@@ -39,7 +39,7 @@ export interface CreateCoffeeEvaluationInput {
 /**
  * Input for creating a bean-only CoffeeEvaluation (without ratings)
  */
-export interface CreateBeanOnlyInput {
+export type CreateBeanOnlyInput = {
   userId: string
   shopName?: string
   shopId?: string | null
@@ -52,7 +52,7 @@ export interface CreateBeanOnlyInput {
 /**
  * Input for updating an existing CoffeeEvaluation
  */
-export interface UpdateCoffeeEvaluationInput {
+export type UpdateCoffeeEvaluationInput = {
   shopName?: string
   shopId?: string | null
   beanName?: string
@@ -68,7 +68,7 @@ export interface UpdateCoffeeEvaluationInput {
 /**
  * Properties for reconstructing a CoffeeEvaluation from persistence
  */
-export interface CoffeeEvaluationProps {
+export type CoffeeEvaluationProps = {
   id: CoffeeEvaluationId
   userId: string
   shopInfo: ShopInfo

--- a/lib/domain/coffee-evaluation/repository.ts
+++ b/lib/domain/coffee-evaluation/repository.ts
@@ -28,7 +28,7 @@ export type EvaluationSortOption =
 /**
  * Filter parameters for querying evaluations
  */
-export interface EvaluationQueryParams {
+export type EvaluationQueryParams = {
   /** Filter by user ID */
   userId?: string
   /** Filter by public/private status */
@@ -46,7 +46,7 @@ export interface EvaluationQueryParams {
 /**
  * Evaluation with display name (for list views with user info)
  */
-export interface EvaluationWithDisplayName {
+export type EvaluationWithDisplayName = {
   evaluation: CoffeeEvaluation
   displayName: string | null
 }
@@ -60,7 +60,7 @@ export interface EvaluationWithDisplayName {
  * - Query building and execution
  * - Error handling and translation
  */
-export interface CoffeeEvaluationRepository {
+export type CoffeeEvaluationRepository = {
   /**
    * Find a single evaluation by ID
    * @param id - Evaluation ID

--- a/lib/domain/coffee-evaluation/value-objects/bean-info.ts
+++ b/lib/domain/coffee-evaluation/value-objects/bean-info.ts
@@ -21,7 +21,7 @@ export const BEAN_INFO_CONSTRAINTS = {
 /**
  * Input for creating BeanInfo
  */
-export interface BeanInfoInput {
+export type BeanInfoInput = {
   beanName: string
   beanType?: string
   roastLevel?: string | null

--- a/lib/domain/coffee-evaluation/value-objects/evaluation-ratings.ts
+++ b/lib/domain/coffee-evaluation/value-objects/evaluation-ratings.ts
@@ -14,7 +14,7 @@ import { Rating, RatingValue } from './rating'
 /**
  * Input for creating EvaluationRatings from raw numbers
  */
-export interface EvaluationRatingsInput {
+export type EvaluationRatingsInput = {
   acidity: number
   bitterness: number
   aroma: number

--- a/lib/domain/coffee-evaluation/value-objects/shop-info.ts
+++ b/lib/domain/coffee-evaluation/value-objects/shop-info.ts
@@ -19,7 +19,7 @@ export const SHOP_INFO_CONSTRAINTS = {
 /**
  * Primitive representation for serialization
  */
-export interface ShopInfoPrimitive {
+export type ShopInfoPrimitive = {
   shopName: string
   shopId: string | null
 }

--- a/lib/domain/llm-settings/entity.ts
+++ b/lib/domain/llm-settings/entity.ts
@@ -1,6 +1,6 @@
 import { LlmSettings } from './value-objects/llm-settings'
 
-export interface UserLlmSettingsProps {
+export type UserLlmSettingsProps = {
   id: string
   userId: string
   settings: LlmSettings

--- a/lib/domain/llm-settings/repository.ts
+++ b/lib/domain/llm-settings/repository.ts
@@ -2,7 +2,7 @@ import type { Result } from '../shared/result'
 import type { UserLlmSettings } from './entity'
 import type { LlmSettings } from './value-objects/llm-settings'
 
-export interface UserLlmSettingsRepository {
+export type UserLlmSettingsRepository = {
   findByUserId(userId: string): Promise<Result<UserLlmSettings | null, Error>>
   save(
     userId: string,

--- a/lib/domain/llm-settings/value-objects/llm-settings.ts
+++ b/lib/domain/llm-settings/value-objects/llm-settings.ts
@@ -1,7 +1,7 @@
 import { Result, ok, fail } from '../../shared/result'
 import { LlmProvider, LlmProviderType } from './llm-provider'
 
-export interface LlmSettingsConfig {
+export type LlmSettingsConfig = {
   provider: LlmProviderType
   providerTemplate?: string | null
   apiUrl?: string | null

--- a/lib/domain/shared/result.ts
+++ b/lib/domain/shared/result.ts
@@ -10,7 +10,7 @@
 /**
  * Represents a successful operation result
  */
-export interface Success<T> {
+export type Success<T> = {
   readonly ok: true
   readonly value: T
 }
@@ -18,7 +18,7 @@ export interface Success<T> {
 /**
  * Represents a failed operation result
  */
-export interface Failure<E = Error> {
+export type Failure<E = Error> = {
   readonly ok: false
   readonly error: E
 }

--- a/lib/domain/shop/entity.ts
+++ b/lib/domain/shop/entity.ts
@@ -7,7 +7,7 @@
  * @module lib/domain/shop/entity
  */
 
-export interface ShopProps {
+export type ShopProps = {
   id: string
   name: string
   normalizedName: string

--- a/lib/domain/shop/repository.ts
+++ b/lib/domain/shop/repository.ts
@@ -9,7 +9,7 @@
 import type { Shop } from './entity'
 import type { Result } from '../shared/result'
 
-export interface ShopRepository {
+export type ShopRepository = {
   findById(id: string): Promise<Result<Shop | null, Error>>
   findOrCreate(name: string): Promise<Result<Shop, Error>>
 }

--- a/lib/types/coffee.ts
+++ b/lib/types/coffee.ts
@@ -53,7 +53,7 @@ export type CoffeeEvaluationWithUser = CoffeeEvaluationDisplay & {
  * Form data for creating a new coffee evaluation
  * Bean name and rating fields are required; shop name, bean type, and roast level are optional
  */
-export interface CoffeeEvaluationFormInput {
+export type CoffeeEvaluationFormInput = {
   shop_name?: string
   bean_type?: string
   bean_name: string
@@ -70,7 +70,7 @@ export interface CoffeeEvaluationFormInput {
  * Form data for editing an existing coffee evaluation
  * All fields are optional for partial updates
  */
-export interface CoffeeEvaluationEditFormInput {
+export type CoffeeEvaluationEditFormInput = {
   shop_name?: string
   bean_type?: string
   bean_name?: string
@@ -86,7 +86,7 @@ export interface CoffeeEvaluationEditFormInput {
 /**
  * User profile form input for creating/updating profile
  */
-export interface UserProfileFormInput {
+export type UserProfileFormInput = {
   display_name: string | null
   bio: string | null
 }
@@ -153,14 +153,14 @@ export const UserProfileValidation = {
  * Coffee evaluation with user profile joined
  * Used for displaying evaluation list with creator info
  */
-export interface CoffeeEvaluationWithProfile extends CoffeeEvaluation {
+export type CoffeeEvaluationWithProfile = {
   user_profile?: UserProfile | null
-}
+} & CoffeeEvaluation
 
 /**
  * Form validation error messages
  */
-export interface FormValidationErrors {
+export type FormValidationErrors = {
   shop_name?: string
   bean_type?: string
   bean_name?: string
@@ -200,7 +200,7 @@ export type CoffeeEvaluationSortOption =
 /**
  * Search and filter parameters for coffee evaluations
  */
-export interface CoffeeEvaluationSearchParams {
+export type CoffeeEvaluationSearchParams = {
   search?: string                          // Search query (shop_name, bean_type, roast_level)
   sort?: CoffeeEvaluationSortOption        // Sort option
   user_id?: string                         // Filter by user

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,6 +2,13 @@
 
 実装のたびに追記する短いログです。長い議事録にはしません。
 
+### 2026-04-29 - 型定義を `type` に統一し ESLint で強制 (issue #20)
+- What: `.eslintrc.json` に `@typescript-eslint/consistent-type-definitions: ['error', 'type']` を追加、`@typescript-eslint/eslint-plugin` と `parser` を直接 devDep に追加(pnpm hoist 経由では eslint が解決できなかったため)、`pnpm lint --fix` で 42 件の `interface` を自動的に `type` に変換、AGENTS.md の Boundaries に 1 行追加、`docs/decisions/2026-04-29-type-vs-interface.md` を新設
+- Why: type と interface が混在(123 vs 42 で 75% が type)してルール不在だったため。type は interface の機能を包含し、union/intersection も書ける。コードベース大多数が既に type 寄りなので統一コストが最小
+- Rejected: interface 統一(union が書けず変換規模も大きい)、両方許容(ESLint で表現できずレビュー依存になる)、オブジェクト形=interface・union=type(機械的に enforce できない)
+- Next: ハーネス PR (#47) → type-debt PR (#48) → この PR の順でマージ
+- Decision: docs/decisions/2026-04-29-type-vs-interface.md
+
 ### 2026-04-29 - typecheck で発見した既存型エラー 316 → 0 件に解消
 - What: `jest.setup.js` を `jest.setup.ts` に改名(jest-dom 型拡張が tsconfig include に反映)で 290 件解消、`lib/types/__tests__/coffee.test.ts` の mock 6 箇所に `notes: null` 追加、`lib/infrastructure/repositories/__tests__/supabase-coffee-evaluation-repository.test.ts` の `makeRow` に `notes: null` 追加、`lib/domain/__tests__/coffee-evaluation.test.ts` の `evaluation.acidity.value` 等を `?.value` に変更(エンティティ refactor で `Rating | null` 化)、`lib/__tests__/actions/coffee.test.ts` の `redirect as jest.Mock` を `as unknown as jest.Mock` に修正、`lib/__tests__/api/coffee.test.ts` の `'newest'` を `'created_at_desc'` に修正、`page.test.tsx` 系の `jest.fn(() => ...)` を `jest.fn((..._args: unknown[]) => ...)` に変更し spread args TS2556 を解消、`evaluation-form.test.tsx` の `new Promise()` を `new Promise<void>()` に変更、`share-link.test.tsx` の不要な `@ts-expect-error` を削除、`coffee/page.test.tsx` の `CoffeeListPage({})` を `CoffeeListPage()` に修正
 - Why: ハーネス PR (#47) で導入した Stop hook の `tsc --noEmit` が CI の盲点だった既存型負債を一気に表面化させたため。最初は 11 件と見積もったが、jest-dom 型拡張未反映が他の型解決をブロックしており、実数は 316 件だった

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript-eslint/eslint-plugin": "^8.51.0",
+    "@typescript-eslint/parser": "^8.51.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9",
     "eslint-config-next": "^15.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,12 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.51.0
+        version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.51.0
+        version: 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)


### PR DESCRIPTION
## Summary

- Issue #20「typeとinterfaceが混在しておりルールを作りたい」への対応
- ESLint ルール `@typescript-eslint/consistent-type-definitions: ['error', 'type']` で `type` 統一を強制
- 既存 42 件の `interface` を `pnpm lint --fix` で自動変換
- **base branch**: `fix/type-debt-from-typecheck` (#48 の上に積む)

## なぜ `type` 統一か (詳細: `docs/decisions/2026-04-29-type-vs-interface.md`)

| 指標 | 値 |
|---|---|
| 現状の `type` 比率 | 75% (123/165) |
| 変換コスト | `type` 統一は 42 ファイル / `interface` 統一は 123 ファイル |
| 表現力 | `type` は union/intersection/mapped/conditional を包含 |
| ESLint auto-fix | あり |

## 変更内容

| カテゴリ | ファイル数 | 内容 |
|---|---|---|
| ESLint 設定 | 1 | `.eslintrc.json` に rule + plugin/parser |
| 依存追加 | `package.json` + `pnpm-lock.yaml` | `@typescript-eslint/{eslint-plugin,parser}` を直接 devDep に |
| 自動変換 | 24 | `interface X { ... }` → `type X = { ... }`、`extends Y` → `& Y` |
| ドキュメント | 2 | `AGENTS.md` Boundaries 1 行追加、`docs/decisions/2026-04-29-type-vs-interface.md` 新設 |

## Test plan

- [x] `pnpm typecheck` → 0 エラー
- [x] `pnpm lint --quiet` → 警告・エラーなし (42 → 0 violations)
- [x] `pnpm test` (Jest) → **503 tests / 66 suites pass**
- [x] `pnpm test --testPathPattern=__tests__/architecture` → 41 pass

## マージ順序

1. #47 (harness) → main
2. #48 (type-debt) → main
3. このPR (lint rule) → main

各 PR の base が連鎖しているため、上から順にマージすれば自然に main に統合される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #20