### PR TITLE
chore: AGENTS.md を spec 駆動で再構成し CLAUDE.md を 2 行ラッパー化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,51 @@
 # AGENTS.md
 
-エージェント (Claude Code / Codex) と人間の共通運用メモ。
-背景・設計方針は `@CLAUDE.md`、用語は `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本とする。
-
 ## Stack
 
-Next.js 15 App Router / TypeScript (strict) / pnpm / Jest / Playwright / Supabase / AI SDK 6.
+Next.js 15 (App Router) / TypeScript 5 strict on Node.js 20、Supabase (PostgreSQL + Auth)、Vercel AI SDK 6、パッケージマネージャは pnpm 10。
 
-## Commands
+## Build & Test
 
 ```
 install      pnpm install --frozen-lockfile
-typecheck    pnpm typecheck         # tsc --noEmit
-lint         pnpm lint              # next lint
-test         pnpm test              # jest (unit/integration)
-e2e          pnpm test:e2e          # playwright
-build        pnpm build
 dev          pnpm dev
-db:migrate   npx supabase migration up
+test         pnpm test            # Jest unit/integration; pnpm test:e2e for Playwright
+typecheck    pnpm typecheck       # tsc --noEmit
+lint         pnpm lint            # next lint
+format       pnpm lint --fix      # 専用 formatter なし、ESLint --fix のみ
 ```
 
-## Boundaries
+## Conventions
 
-- 用語は `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` の正本に従う（例: `CoffeeEvaluation` ✓ / `CoffeeReview` ✗）。
-- Clean Architecture 層依存: `domain ← application ← infrastructure / presentation`。`lib/domain/**` は外側を import しない。
-- 型定義は `type` を使う（`interface` 禁止 / lint で強制。詳細: `@docs/decisions/2026-04-29-type-vs-interface.md`）。
-- UI 文言は日本語、コードは英語。
+- 用語は `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本にコードと UI で揃える。なぜ: 同概念に別語を当てると DB / API / UI で見え方が割れ、毎回「別物か？」の判断コストが乗るため。
+- 型定義は `type` のみ（`interface` 禁止 / lint 強制）。なぜ: 既に 75% が `type` で、`type` は union/intersection を含めて `interface` を機能的に包含するため統一コスト最小（詳細 `docs/decisions/2026-04-29-type-vs-interface.md`）。
+- Clean Architecture の依存は `domain ← application ← infrastructure / presentation` の単方向のみ。なぜ: 双方向化すると変更影響が指数的に増え、テスト境界も曖昧になるため。
+- 実装後は `memory-bank/progress.md` に 1 エントリ追記（What / Why / Rejected / Next 形式）。なぜ: コミットメッセージには「却下案」「次の課題」が残らず、将来の自分やエージェントが読める情報が失われるため。
+- 再迷走しそうな設計判断は `docs/decisions/<date>-<topic>.md` に残す。なぜ: 命名・責務分割の判断はコードを読んでも復元できず、判断の粒度を ADR より細かく取りたいため。
+- UI 文言は日本語、コード・コメント・コミットメッセージは英語または日本語。なぜ: ユーザー文脈は日本語固定だが、技術用語は英語の方が型定義・ライブラリ検索で当たりやすいため。
 
-## Workflow
+## Programmatic checks the agent MUST run before finishing
 
-1. ブランチ: `feature/<name>` / `fix/<name>` / `chore/<name>`
-2. 変更は意味単位で行う（小さな修正でも別意図なら分ける）
-3. 影響に応じて `pnpm typecheck` / `pnpm lint` / `pnpm test` を回す
-4. 実装完了後、`memory-bank/progress.md` に 1 エントリ追記（形式は `@CLAUDE.md` 参照）
-5. 将来また迷う設計判断のみ `docs/decisions/` に短く残す
+1. `pnpm typecheck` — 型エラーゼロを保証する。Stop hook でも自動実行されるが、終了前に明示確認する。
+2. `pnpm lint --quiet` — `consistent-type-definitions` などプロジェクトルール違反ゼロを保証する。
+3. `pnpm test --testPathPattern=__tests__/architecture` — Clean Arch 層境界違反ゼロを保証する（< 1 秒）。
+4. 振る舞い変更を伴う場合は `pnpm test` 全体（66 suites / 503 tests）で回帰を確認する。
+5. UI 変更を含む場合は `pnpm dev` でブラウザ動作確認、または `pnpm test:e2e` で関連シナリオを通す。
 
-## Forbidden
+## Out of scope
 
-- `supabase db reset`（データ全消去）
-- `git commit --no-verify` / `git push --force` / `git rebase -i`
-- `.env` / `.env.local` / `secrets/**` の読書
-- 用語集違反の命名（リファクタは Ubiquitous Language を最初に確認）
+- `.env` / `.env.local` / `secrets/**` — 読み・書き・コミットいずれも禁止。
+- `supabase db reset` — データ全消去のため絶対に実行しない（過去事故あり）。
+- `git commit --no-verify` / `git push --force` / `git rebase -i` — フックスキップ・履歴破壊系は明示許可なき限り禁止。
+- `pnpm-lock.yaml` の手動編集 — 必ず `pnpm` 経由で更新する。
+- `next-env.d.ts` — Next.js が自動生成するため触らない。
+- 適用済みの `supabase/migrations/*.sql` のリネーム・編集 — 既存マイグレーションは不変、新ファイルを足す形で対応する。
 
-## Skills (shared with Codex)
+## More context (load on demand)
 
-`.agents/skills/` を一次格納とし、Claude Code は `.claude/skills/` の symlink から参照する。
-
-- `coffee-ubiquitous-language` — 用語の正誤チェック
-- `progress-logger` — `memory-bank/progress.md` 追記の正規化
-- `clean-arch-boundary` — 層境界違反の確認
-
-## References
-
-- `@CLAUDE.md` — 設計方針 / WHY・HOW
-- `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` — 用語の正本
-- `@e2e/README.md` — E2E 実行手順
+- `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` — ドメイン用語の正本
+- `@docs/decisions/` — 過去の設計判断
 - `@memory-bank/progress.md` — 実装ログ
-- `@docs/decisions/` — 設計判断の記録
+- `@e2e/README.md` — Playwright E2E 実行手順
+- `@.claude/agents/` — サブエージェント定義 (researcher / reviewer / tester ほか)
+- `@.agents/skills/` — Claude / Codex 共通 SKILL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,5 @@
 # AGENTS.md
 
-## Stack
+@CLAUDE.md
 
-Next.js 15 (App Router) / TypeScript 5 strict on Node.js 20、Supabase (PostgreSQL + Auth)、Vercel AI SDK 6、パッケージマネージャは pnpm 10。
-
-## Build & Test
-
-```
-install      pnpm install --frozen-lockfile
-dev          pnpm dev
-test         pnpm test            # Jest unit/integration; pnpm test:e2e for Playwright
-typecheck    pnpm typecheck       # tsc --noEmit
-lint         pnpm lint            # next lint
-format       pnpm lint --fix      # 専用 formatter なし、ESLint --fix のみ
-```
-
-## Conventions
-
-- 用語は `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本にコードと UI で揃える。なぜ: 同概念に別語を当てると DB / API / UI で見え方が割れ、毎回「別物か？」の判断コストが乗るため。
-- 型定義は `type` のみ（`interface` 禁止 / lint 強制）。なぜ: 既に 75% が `type` で、`type` は union/intersection を含めて `interface` を機能的に包含するため統一コスト最小（詳細 `docs/decisions/2026-04-29-type-vs-interface.md`）。
-- Clean Architecture の依存は `domain ← application ← infrastructure / presentation` の単方向のみ。なぜ: 双方向化すると変更影響が指数的に増え、テスト境界も曖昧になるため。
-- 実装後は `memory-bank/progress.md` に 1 エントリ追記（What / Why / Rejected / Next 形式）。なぜ: コミットメッセージには「却下案」「次の課題」が残らず、将来の自分やエージェントが読める情報が失われるため。
-- 再迷走しそうな設計判断は `docs/decisions/<date>-<topic>.md` に残す。なぜ: 命名・責務分割の判断はコードを読んでも復元できず、判断の粒度を ADR より細かく取りたいため。
-- UI 文言は日本語、コード・コメント・コミットメッセージは英語または日本語。なぜ: ユーザー文脈は日本語固定だが、技術用語は英語の方が型定義・ライブラリ検索で当たりやすいため。
-
-## Programmatic checks the agent MUST run before finishing
-
-1. `pnpm typecheck` — 型エラーゼロを保証する。Stop hook でも自動実行されるが、終了前に明示確認する。
-2. `pnpm lint --quiet` — `consistent-type-definitions` などプロジェクトルール違反ゼロを保証する。
-3. `pnpm test --testPathPattern=__tests__/architecture` — Clean Arch 層境界違反ゼロを保証する（< 1 秒）。
-4. 振る舞い変更を伴う場合は `pnpm test` 全体（66 suites / 503 tests）で回帰を確認する。
-5. UI 変更を含む場合は `pnpm dev` でブラウザ動作確認、または `pnpm test:e2e` で関連シナリオを通す。
-
-## Out of scope
-
-- `.env` / `.env.local` / `secrets/**` — 読み・書き・コミットいずれも禁止。
-- `supabase db reset` — データ全消去のため絶対に実行しない（過去事故あり）。
-- `git commit --no-verify` / `git push --force` / `git rebase -i` — フックスキップ・履歴破壊系は明示許可なき限り禁止。
-- `pnpm-lock.yaml` の手動編集 — 必ず `pnpm` 経由で更新する。
-- `next-env.d.ts` — Next.js が自動生成するため触らない。
-- 適用済みの `supabase/migrations/*.sql` のリネーム・編集 — 既存マイグレーションは不変、新ファイルを足す形で対応する。
-
-## More context (load on demand)
-
-- `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` — ドメイン用語の正本
-- `@docs/decisions/` — 過去の設計判断
-- `@memory-bank/progress.md` — 実装ログ
-- `@e2e/README.md` — Playwright E2E 実行手順
-- `@.claude/agents/` — サブエージェント定義 (researcher / reviewer / tester ほか)
-- `@.agents/skills/` — Claude / Codex 共通 SKILL
+このリポジトリの規約と運用ルールは `CLAUDE.md` を SSoT として集約しています。Codex など `AGENTS.md` のみを読むツールも、上の `@CLAUDE.md` 参照によって同一内容を取り込みます。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,82 +1,10 @@
 # CLAUDE.md
 
-## WHY: Project Purpose
+@AGENTS.md
 
-A personal coffee journal to record cafe visits and coffee experiences.
-Helps enthusiasts track their coffee journey, discover patterns, and explore new tastes.
+## Claude-specific
 
-**Audience**: Coffee enthusiasts (personal use & community sharing)
-**Language**: Japanese (UI/content), English (docs)
+`.claude/skills/` のスキルは description だけでなく状況に合致したら能動的に呼び出す:
 
----
-
-## WHAT: Architecture & Components
-
-### Architecture: Clean Architecture + DDD
-
-- **Domain**: Entities, Value Objects (`lib/domain/`)
-- **Application**: Use Cases, DTOs (`lib/application/`)
-- **Infrastructure**: Supabase, Repository (`lib/infrastructure/`)
-- **Presentation**: Next.js, Server Actions (`app/`, `lib/actions/`)
-
-**Skills**: claude-md-creator, nextjs-best-practices, e2e-testing (`.claude/skills/`)
-
----
-
-## HOW: Development Guidelines
-
-### Feature Development Workflow
-
-1. Branch: `git checkout -b feature/name`
-2. spec-workflow MCP: Requirements → Design → Tasks → Implementation
-3. TDD: Test → Fail → Implement → Pass → Refactor (80%+ coverage)
-
-### Ubiquitous Language (MANDATORY)
-
-**Before coding**: Check `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md`
-**Usage**: `CoffeeEvaluation` ✓ / `CoffeeReview` ✗ (Code), "評価" ✓ / "レビュー" ✗ (UI)
-
-### Next.js & Testing
-
-- Server Components first, Container/Presentational, Composition over drilling
-- Unit: Jest + Testing Library | Integration: API, DB | E2E: Playwright (`e2e/README.md`)
-
-### Key Resources
-
-- `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` - Term reference (推奨)
-- `.claude/skills/` - claude-md-creator, nextjs-best-practices
-
----
-
-### Continuous Recording (継続記録ルール)
-
-小さな修正も意味単位として扱い、作業のたびに記録を残す。
-
-**記録先の使い分け**
-
-| 種別 | 記録先 |
-|------|--------|
-| 日常の実装・修正・リファクタ | `memory-bank/progress.md` に追記 |
-| 将来も迷い直す可能性がある設計判断 | `docs/decisions/` に個別ファイルを作成 |
-
-**progress.md エントリー形式**
-
-```
-### YYYY-MM-DD - 変更の要点（一行）
-- What: 何を変えたか
-- Why: なぜ変えたか
-- Rejected: 却下した案（なければ省略）
-- Next: 次に確認・改善すべき点
-- Decision: docs/decisions/... があれば記載
-```
-
-**Claude の振る舞いルール**
-
-- 実装・修正・リファクタを完了したら `memory-bank/progress.md` に追記する
-- 1タスク = 1エントリー（複数ファイルにまたがっても1つにまとめてよい）
-- エントリーは短く。長い説明が必要な場合は `docs/decisions/` に移す
-- `docs/decisions/` への移動判断基準: 「同じ迷いを将来もしそうか？」→ Yes なら移す
-
----
-
-**Last Updated**: 2026-03-11 | **Version**: 1.2.0
+- `coffee-ubiquitous-language` / `progress-logger` / `clean-arch-boundary` — リポジトリ固有の運用支援
+- `nextjs-best-practices` / `e2e-testing` / `sudo-modeling` / `claude-md-creator` — 設計・テスト・モデリング

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,48 @@
 # CLAUDE.md
 
-@AGENTS.md
+エージェント (Claude Code / Codex) と人間の共通運用メモ。本ファイルが正本（SSoT）で、AGENTS.md からは `@CLAUDE.md` で参照される。
+用語は `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本とする。
+
+## Stack
+
+Next.js 15 (App Router) / TypeScript 5 strict on Node.js 20、Supabase (PostgreSQL + Auth)、Vercel AI SDK 6、パッケージマネージャは pnpm 10。
+
+## Build & Test
+
+```
+install      pnpm install --frozen-lockfile
+dev          pnpm dev
+test         pnpm test            # Jest unit/integration; pnpm test:e2e for Playwright
+typecheck    pnpm typecheck       # tsc --noEmit
+lint         pnpm lint            # next lint
+format       pnpm lint --fix      # 専用 formatter なし、ESLint --fix のみ
+```
+
+## Conventions
+
+- 用語は `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本にコードと UI で揃える。なぜ: 同概念に別語を当てると DB / API / UI で見え方が割れ、毎回「別物か？」の判断コストが乗るため。
+- 型定義は `type` のみ（`interface` 禁止 / lint 強制）。なぜ: 既に 75% が `type` で、`type` は union/intersection を含めて `interface` を機能的に包含するため統一コスト最小（詳細 `docs/decisions/2026-04-29-type-vs-interface.md`）。
+- Clean Architecture の依存は `domain ← application ← infrastructure / presentation` の単方向のみ。なぜ: 双方向化すると変更影響が指数的に増え、テスト境界も曖昧になるため。
+- 実装後は `memory-bank/progress.md` に 1 エントリ追記（What / Why / Rejected / Next 形式）。なぜ: コミットメッセージには「却下案」「次の課題」が残らず、将来の自分やエージェントが読める情報が失われるため。
+- 再迷走しそうな設計判断は `docs/decisions/<date>-<topic>.md` に残す。なぜ: 命名・責務分割の判断はコードを読んでも復元できず、判断の粒度を ADR より細かく取りたいため。
+- UI 文言は日本語、コード・コメント・コミットメッセージは英語または日本語。なぜ: ユーザー文脈は日本語固定だが、技術用語は英語の方が型定義・ライブラリ検索で当たりやすいため。
+
+## Programmatic checks the agent MUST run before finishing
+
+1. `pnpm typecheck` — 型エラーゼロを保証する。Stop hook でも自動実行されるが、終了前に明示確認する。
+2. `pnpm lint --quiet` — `consistent-type-definitions` などプロジェクトルール違反ゼロを保証する。
+3. `pnpm test --testPathPattern=__tests__/architecture` — Clean Arch 層境界違反ゼロを保証する（< 1 秒）。
+4. 振る舞い変更を伴う場合は `pnpm test` 全体（66 suites / 503 tests）で回帰を確認する。
+5. UI 変更を含む場合は `pnpm dev` でブラウザ動作確認、または `pnpm test:e2e` で関連シナリオを通す。
+
+## Out of scope
+
+- `.env` / `.env.local` / `secrets/**` — 読み・書き・コミットいずれも禁止。
+- `supabase db reset` — データ全消去のため絶対に実行しない（過去事故あり）。
+- `git commit --no-verify` / `git push --force` / `git rebase -i` — フックスキップ・履歴破壊系は明示許可なき限り禁止。
+- `pnpm-lock.yaml` の手動編集 — 必ず `pnpm` 経由で更新する。
+- `next-env.d.ts` — Next.js が自動生成するため触らない。
+- 適用済みの `supabase/migrations/*.sql` のリネーム・編集 — 既存マイグレーションは不変、新ファイルを足す形で対応する。
 
 ## Claude-specific
 
@@ -8,3 +50,12 @@
 
 - `coffee-ubiquitous-language` / `progress-logger` / `clean-arch-boundary` — リポジトリ固有の運用支援
 - `nextjs-best-practices` / `e2e-testing` / `sudo-modeling` / `claude-md-creator` — 設計・テスト・モデリング
+
+## More context (load on demand)
+
+- `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` — ドメイン用語の正本
+- `@docs/decisions/` — 過去の設計判断
+- `@memory-bank/progress.md` — 実装ログ
+- `@e2e/README.md` — Playwright E2E 実行手順
+- `@.claude/agents/` — サブエージェント定義 (researcher / reviewer / tester ほか)
+- `@.agents/skills/` — Claude / Codex 共通 SKILL

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,6 +2,13 @@
 
 実装のたびに追記する短いログです。長い議事録にはしません。
 
+### 2026-04-29 - AGENTS.md を spec 駆動で再構成し CLAUDE.md を 2 行ラッパー化
+- What: AGENTS.md を 6 セクション固定テンプレート(Stack / Build & Test / Conventions / Programmatic checks / Out of scope / More context)に書き換え 51 行に圧縮、CLAUDE.md を `@AGENTS.md` 参照 + Claude 固有スキル利用方針のみの 10 行に縮約
+- Why: ETHチューリッヒ「Lost in Instructions」研究準拠で冗長指示を排除。AGENTS.md を single source of truth にし、Claude/Codex/Cursor 間のドリフトを防ぐ。Conventions の各項に「なぜ」を 1 行添えることで grey-area 判断を効かせやすくする
+- Rejected: AGENTS.md と CLAUDE.md に責務分散(指示の重複が出る)、CLAUDE.md を完全な 2 行ラッパーに(`.claude/skills/` の能動利用方針はユーザ判断で残す)、`Last Updated`/`Version` メタ情報の保持(git log で十分)
+- Next: ハーネス系 PR スタック (#47 → #48 → #49 → このPR) を順次マージ
+- Decision: spec-workflow MCP は AGENTS.md に書かない(任意ツール扱い)、`.claude/skills/` の能動利用は CLAUDE.md に明記
+
 ### 2026-04-29 - 型定義を `type` に統一し ESLint で強制 (issue #20)
 - What: `.eslintrc.json` に `@typescript-eslint/consistent-type-definitions: ['error', 'type']` を追加、`@typescript-eslint/eslint-plugin` と `parser` を直接 devDep に追加(pnpm hoist 経由では eslint が解決できなかったため)、`pnpm lint --fix` で 42 件の `interface` を自動的に `type` に変換、AGENTS.md の Boundaries に 1 行追加、`docs/decisions/2026-04-29-type-vs-interface.md` を新設
 - Why: type と interface が混在(123 vs 42 で 75% が type)してルール不在だったため。type は interface の機能を包含し、union/intersection も書ける。コードベース大多数が既に type 寄りなので統一コストが最小


### PR DESCRIPTION
## Summary

- AGENTS.md を spec 駆動の 6 セクション固定テンプレートに書き換え（commit fc16f48）
- その後、Claude Code の auto-load 仕様に合わせて **SSoT を CLAUDE.md に反転**（commit 484e3b8）
- 最終形: **CLAUDE.md = SSoT (61 行) / AGENTS.md = wrapper (5 行)**
- **base branch**: `chore/lint-type-vs-interface` (#49) — マージ後は main に向け直る予定

## 2 段階の commit 履歴

### Commit 1: spec 駆動再構成 (fc16f48)
旧 AGENTS.md (117 行) を 6 セクション固定テンプレートで 51 行に再構成し、CLAUDE.md を 10 行のラッパーに。

セクション順:
- `## Stack` / `## Build & Test` / `## Conventions` / `## Programmatic checks` / `## Out of scope` / `## More context`

排除した要素 (spec 禁止事項に準拠):
- ❌ ディレクトリ構造列挙
- ❌ 無意味な訓示（"Coffee enthusiasts" など）
- ❌ スタイル指示（リンタの担当）

### Commit 2: SSoT 反転 (484e3b8)
Claude Code は CLAUDE.md のみを auto-load する仕様のため、SSoT を AGENTS.md に置くと CLAUDE.md は `@AGENTS.md` 経由でしか正本に届かず、leaf 単体では「何もわからない」状態だった。

これを反転し、**CLAUDE.md = SSoT / AGENTS.md = wrapper** にした。

参照グラフ（一方向）:

```
   CLAUDE.md (SSoT, Claude Code が auto-load)
        ↑
        │ @CLAUDE.md
        │
   AGENTS.md (wrapper, Codex 等の慣習 entry)
```

| 起点 | 経路 |
|---|---|
| Claude Code | CLAUDE.md (auto) → 全部読む |
| Codex | AGENTS.md (auto) → @CLAUDE.md → 全部読む |

## 行数

| | 旧 (Commit 1) | 最終 (Commit 2) | 変化 |
|---|---|---|---|
| AGENTS.md | 51 | 5 | -46 |
| CLAUDE.md | 10 | 61 | +51 |
| 合計 | 61 | 66 | +5 |

## 下流 PR への影響

**この PR がマージされた時、#51〜#54 は rebase が必要になります**:

- **#51 (chore/skills-and-subagents)**: 旧 AGENTS.md の Conventions に「researcher subagent を使う」という 1 行を追加していた。新構造では CLAUDE.md の Conventions に同じ内容を追加する形に rebase 修正が必要
- **#52, #53, #54**: AGENTS.md / CLAUDE.md を直接編集していないため、ファイル内容の rebase 修正は無し。ただし、各 PR 内のドキュメント記述が「AGENTS.md = SSoT」前提のものは reviewer が読み替える必要あり

## 却下した案

- **AGENTS.md への統合** — SSoT 肥大化の "lost in instructions" リスク
- **README への合体** — セットアップ文脈と混ざり長大化
- **複数ファイル分散** — 30 分 budget に収まらない（onboarding doc 視点）
- **SSoT を AGENTS.md に置く（旧設計）** — Claude Code auto-load 仕様と整合せず、leaf としての CLAUDE.md が空っぽに見える

## Test plan

- [x] AGENTS.md ≤ 30 行（実 5 行）
- [x] CLAUDE.md ≤ 120 行（実 61 行）
- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint --quiet` → 警告なし
- [x] arch test (layer-dependency) → 41 pass

## マージ順序

1. #47 → main ✓ MERGED
2. #48 → MERGED
3. #49 → MERGED
4. **このPR (#50)** → main
5. #51〜#54 → 順次 rebase + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)