### PR TITLE
refactor: SSoT を CLAUDE.md に反転、AGENTS.md を wrapper 化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,5 @@
 # AGENTS.md
 
-## Stack
+@CLAUDE.md
 
-Next.js 15 (App Router) / TypeScript 5 strict on Node.js 20、Supabase (PostgreSQL + Auth)、Vercel AI SDK 6、パッケージマネージャは pnpm 10。
-
-## Build & Test
-
-```
-install      pnpm install --frozen-lockfile
-dev          pnpm dev
-test         pnpm test            # Jest unit/integration; pnpm test:e2e for Playwright
-typecheck    pnpm typecheck       # tsc --noEmit
-lint         pnpm lint            # next lint
-format       pnpm lint --fix      # 専用 formatter なし、ESLint --fix のみ
-```
-
-## Conventions
-
-- 用語は `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本にコードと UI で揃える。なぜ: 同概念に別語を当てると DB / API / UI で見え方が割れ、毎回「別物か？」の判断コストが乗るため。
-- 型定義は `type` のみ（`interface` 禁止 / lint 強制）。なぜ: 既に 75% が `type` で、`type` は union/intersection を含めて `interface` を機能的に包含するため統一コスト最小（詳細 `docs/decisions/2026-04-29-type-vs-interface.md`）。
-- Clean Architecture の依存は `domain ← application ← infrastructure / presentation` の単方向のみ。なぜ: 双方向化すると変更影響が指数的に増え、テスト境界も曖昧になるため。
-- 実装後は `memory-bank/progress.md` に 1 エントリ追記（What / Why / Rejected / Next 形式）。なぜ: コミットメッセージには「却下案」「次の課題」が残らず、将来の自分やエージェントが読める情報が失われるため。
-- 再迷走しそうな設計判断は `docs/decisions/<date>-<topic>.md` に残す。なぜ: 命名・責務分割の判断はコードを読んでも復元できず、判断の粒度を ADR より細かく取りたいため。
-- UI 文言は日本語、コード・コメント・コミットメッセージは英語または日本語。なぜ: ユーザー文脈は日本語固定だが、技術用語は英語の方が型定義・ライブラリ検索で当たりやすいため。
-- Use the researcher subagent when you need to locate code patterns; never grep yourself in the parent context. なぜ: 大量の grep 結果が親 context window を圧迫し、後続判断の精度が落ちるため。
-
-## Programmatic checks the agent MUST run before finishing
-
-1. `pnpm typecheck` — 型エラーゼロを保証する。Stop hook でも自動実行されるが、終了前に明示確認する。
-2. `pnpm lint --quiet` — `consistent-type-definitions` などプロジェクトルール違反ゼロを保証する。
-3. `pnpm test --testPathPattern=__tests__/architecture` — Clean Arch 層境界違反ゼロを保証する（< 1 秒）。
-4. 振る舞い変更を伴う場合は `pnpm test` 全体（66 suites / 503 tests）で回帰を確認する。
-5. UI 変更を含む場合は `pnpm dev` でブラウザ動作確認、または `pnpm test:e2e` で関連シナリオを通す。
-
-## Out of scope
-
-- `.env` / `.env.local` / `secrets/**` — 読み・書き・コミットいずれも禁止。
-- `supabase db reset` — データ全消去のため絶対に実行しない（過去事故あり）。
-- `git commit --no-verify` / `git push --force` / `git rebase -i` — フックスキップ・履歴破壊系は明示許可なき限り禁止。
-- `pnpm-lock.yaml` の手動編集 — 必ず `pnpm` 経由で更新する。
-- `next-env.d.ts` — Next.js が自動生成するため触らない。
-- 適用済みの `supabase/migrations/*.sql` のリネーム・編集 — 既存マイグレーションは不変、新ファイルを足す形で対応する。
-
-## More context (load on demand)
-
-- `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` — ドメイン用語の正本
-- `@docs/decisions/` — 過去の設計判断
-- `@memory-bank/progress.md` — 実装ログ
-- `@e2e/README.md` — Playwright E2E 実行手順
-- `@.claude/agents/` — サブエージェント定義 (researcher / reviewer / tester ほか)
-- `@.agents/skills/` — Claude / Codex 共通 SKILL
+このリポジトリの規約と運用ルールは `CLAUDE.md` を SSoT として集約しています。Codex など `AGENTS.md` のみを読むツールも、上の `@CLAUDE.md` 参照によって同一内容を取り込みます。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,49 @@
 # CLAUDE.md
 
-@AGENTS.md
+エージェント (Claude Code / Codex) と人間の共通運用メモ。本ファイルが正本（SSoT）で、AGENTS.md からは `@CLAUDE.md` で参照される。
+用語は `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本とする。
+
+## Stack
+
+Next.js 15 (App Router) / TypeScript 5 strict on Node.js 20、Supabase (PostgreSQL + Auth)、Vercel AI SDK 6、パッケージマネージャは pnpm 10。
+
+## Build & Test
+
+```
+install      pnpm install --frozen-lockfile
+dev          pnpm dev
+test         pnpm test            # Jest unit/integration; pnpm test:e2e for Playwright
+typecheck    pnpm typecheck       # tsc --noEmit
+lint         pnpm lint            # next lint
+format       pnpm lint --fix      # 専用 formatter なし、ESLint --fix のみ
+```
+
+## Conventions
+
+- 用語は `docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` を正本にコードと UI で揃える。なぜ: 同概念に別語を当てると DB / API / UI で見え方が割れ、毎回「別物か？」の判断コストが乗るため。
+- 型定義は `type` のみ（`interface` 禁止 / lint 強制）。なぜ: 既に 75% が `type` で、`type` は union/intersection を含めて `interface` を機能的に包含するため統一コスト最小（詳細 `docs/decisions/2026-04-29-type-vs-interface.md`）。
+- Clean Architecture の依存は `domain ← application ← infrastructure / presentation` の単方向のみ。なぜ: 双方向化すると変更影響が指数的に増え、テスト境界も曖昧になるため。
+- 実装後は `memory-bank/progress.md` に 1 エントリ追記（What / Why / Rejected / Next 形式）。なぜ: コミットメッセージには「却下案」「次の課題」が残らず、将来の自分やエージェントが読める情報が失われるため。
+- 再迷走しそうな設計判断は `docs/decisions/<date>-<topic>.md` に残す。なぜ: 命名・責務分割の判断はコードを読んでも復元できず、判断の粒度を ADR より細かく取りたいため。
+- UI 文言は日本語、コード・コメント・コミットメッセージは英語または日本語。なぜ: ユーザー文脈は日本語固定だが、技術用語は英語の方が型定義・ライブラリ検索で当たりやすいため。
+- Use the researcher subagent when you need to locate code patterns; never grep yourself in the parent context. なぜ: 大量の grep 結果が親 context window を圧迫し、後続判断の精度が落ちるため。
+
+## Programmatic checks the agent MUST run before finishing
+
+1. `pnpm typecheck` — 型エラーゼロを保証する。Stop hook でも自動実行されるが、終了前に明示確認する。
+2. `pnpm lint --quiet` — `consistent-type-definitions` などプロジェクトルール違反ゼロを保証する。
+3. `pnpm test --testPathPattern=__tests__/architecture` — Clean Arch 層境界違反ゼロを保証する（< 1 秒）。
+4. 振る舞い変更を伴う場合は `pnpm test` 全体（66 suites / 503 tests）で回帰を確認する。
+5. UI 変更を含む場合は `pnpm dev` でブラウザ動作確認、または `pnpm test:e2e` で関連シナリオを通す。
+
+## Out of scope
+
+- `.env` / `.env.local` / `secrets/**` — 読み・書き・コミットいずれも禁止。
+- `supabase db reset` — データ全消去のため絶対に実行しない（過去事故あり）。
+- `git commit --no-verify` / `git push --force` / `git rebase -i` — フックスキップ・履歴破壊系は明示許可なき限り禁止。
+- `pnpm-lock.yaml` の手動編集 — 必ず `pnpm` 経由で更新する。
+- `next-env.d.ts` — Next.js が自動生成するため触らない。
+- 適用済みの `supabase/migrations/*.sql` のリネーム・編集 — 既存マイグレーションは不変、新ファイルを足す形で対応する。
 
 ## Claude-specific
 
@@ -8,3 +51,13 @@
 
 - `coffee-ubiquitous-language` / `progress-logger` / `clean-arch-boundary` — リポジトリ固有の運用支援
 - `nextjs-best-practices` / `e2e-testing` / `sudo-modeling` / `claude-md-creator` — 設計・テスト・モデリング
+
+## More context (load on demand)
+
+- `@docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md` — ドメイン用語の正本
+- `@docs/decisions/` — 過去の設計判断
+- `@memory-bank/progress.md` — 実装ログ
+- `@docs/agent-onboarding.md` — 初見開発者 30 分向けハーネス全体像
+- `@e2e/README.md` — Playwright E2E 実行手順
+- `@.claude/agents/` — サブエージェント定義 (researcher / reviewer / tester ほか)
+- `@.agents/skills/` — Claude / Codex 共通 SKILL

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -20,9 +20,9 @@ flowchart TB
 
   subgraph SSoT["Source of Truth"]
     direction LR
-    A["AGENTS.md<br/>運用 SSoT"]
-    C["CLAUDE.md<br/>= @AGENTS.md + Claude固有"]
-    C -->|参照| A
+    C["CLAUDE.md<br/>運用 SSoT (auto-load by Claude Code)"]
+    A["AGENTS.md<br/>= @CLAUDE.md (wrapper for Codex)"]
+    A -->|参照| C
   end
 
   subgraph Skills[".agents/skills/ ⇄ .claude/skills/ (symlink)"]
@@ -69,8 +69,8 @@ flowchart TB
 
 | 要素 | 責任 |
 |---|---|
-| **AGENTS.md** | エージェント・人間共通の運用 SSoT（コマンド / 規約 / 禁則 / 参照ポインタ） |
-| **CLAUDE.md** | `@AGENTS.md` 参照 + Claude 固有の skill 利用方針のみ（10 行） |
+| **CLAUDE.md** | エージェント・人間共通の運用 SSoT（コマンド / 規約 / 禁則 / Claude 固有 / 参照ポインタ）。Claude Code が auto-load する |
+| **AGENTS.md** | Codex 等が読む慣習ファイル。`@CLAUDE.md` のみを含む 5 行のラッパー |
 | **`.agents/skills/`** | 再現可能ワークフロー（Codex も読む一次格納） |
 | **`.claude/skills/`** | `.agents/skills/` への symlink（Claude Code 用参照点） |
 | **`.claude/agents/`** | サブエージェント定義（`tools:` で最小権限） |
@@ -87,7 +87,7 @@ flowchart TB
 
 | 触れていい | 触らない |
 |---|---|
-| `AGENTS.md` の Conventions に新規 1 行追加 | `next-env.d.ts`（Next.js 自動生成） |
+| `CLAUDE.md` の Conventions に新規 1 行追加（SSoT） | `next-env.d.ts`（Next.js 自動生成） |
 | `.agents/skills/<name>/SKILL.md` 新規・既存改善 | 適用済 `supabase/migrations/*.sql`（不変） |
 | `.claude/agents/<name>.md` 新規・既存改善 | `pnpm-lock.yaml`（必ず `pnpm` 経由で更新） |
 | `evals/dataset.jsonl` 新規ケース追加 | `.env` / `.env.local` / `secrets/**` |
@@ -102,7 +102,7 @@ flowchart TB
 失敗観測
   ↓
 既存ハーネスのどこで防げたか確認
-  ├── 規約違反 →  AGENTS.md Conventions に 1 行追加（why 付き）
+  ├── 規約違反 →  CLAUDE.md Conventions に 1 行追加（why 付き）
   ├── 手順抜け →  既存 SKILL に追記、または新規 SKILL
   ├── 機械検出可 → ESLint ルール / Stop hook
   └── 用語ぶれ → docs/UBIQUITOUS_LANGUAGE_DICTIONARY.md 追記
@@ -164,7 +164,7 @@ codex
 # IDE 連携 (VS Code 拡張) からも同じ harness を読む
 ```
 
-両者とも `AGENTS.md` を SSoT とする。Skills は `.agents/skills/` を一次に置き、`.claude/skills/` は symlink なので Claude / Codex 双方から同じ内容を参照する。
+両者とも `CLAUDE.md` を SSoT とする（Codex は `AGENTS.md` の `@CLAUDE.md` 参照経由で同内容を取り込む）。Skills は `.agents/skills/` を一次に置き、`.claude/skills/` は symlink なので Claude / Codex 双方から同じ内容を参照する。
 
 ---
 
@@ -197,8 +197,8 @@ description: 機能設計・実装・テスト・PR・リリースまで全部�
 |---|---|---|
 | **megaskill** | 1 SKILL 複数ジョブで適用判断が曖昧化 | 1 SKILL = 1 ジョブ |
 | **MCP 積みすぎ** | ツール検索の精度低下、起動時間増 | 必要なものだけ。本リポは `spec-workflow` のみ |
-| **CLAUDE.md 500 行超** | auto-load context window 圧迫 | 本リポは 10 行 + `@AGENTS.md` |
-| **「念のため」指示** | リンタの仕事を奪う / ノイズ | 業界標準は AGENTS.md に書かない |
+| **CLAUDE.md 500 行超** | auto-load context window 圧迫 | 本リポは 63 行（arch test で ≤120 強制） |
+| **「念のため」指示** | リンタの仕事を奪う / ノイズ | 業界標準は CLAUDE.md に書かない |
 | **silent disable** | `if: secret != ''` で skip し緑になる | 動かないなら明示的に外す（本リポの evals が CI 不在なのは意図的） |
 | **subagent に full Bash 付与** | 想定外コマンド実行リスク | researcher / reviewer は Read+Grep のみ |
 | **expected を judge に渡す eval** | reward hacking で score 膨張 | criteria だけで pass/fail（leak 防止） |
@@ -276,7 +276,7 @@ EOF
 
 PR 作成後、以下を自問する:
 
-- 今回エージェントは AGENTS.md / SKILL のどれに従って動いたか？
+- 今回エージェントは CLAUDE.md / SKILL のどれに従って動いたか？
 - 従わなかった or 不足だった部分はあるか？
 - あれば「**4. ミスをしたときのフロー**」に従ってハーネスを改善する PR を別途出す
 

--- a/lib/__tests__/architecture/doc-size.test.ts
+++ b/lib/__tests__/architecture/doc-size.test.ts
@@ -3,9 +3,12 @@ import * as path from 'node:path'
 
 const ROOT = path.resolve(__dirname, '..', '..', '..')
 
+// CLAUDE.md is the SSoT (auto-loaded by Claude Code). AGENTS.md is a thin
+// wrapper containing only `@CLAUDE.md` for tools that read AGENTS.md by
+// convention (e.g., Codex). Limits are swapped accordingly.
 const LIMITS = [
-  { file: 'AGENTS.md', max: 120 },
-  { file: 'CLAUDE.md', max: 30 },
+  { file: 'CLAUDE.md', max: 120 },
+  { file: 'AGENTS.md', max: 30 },
 ] as const
 
 describe('Doc size limits (anti "lost in instructions")', () => {

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,6 +2,13 @@
 
 実装のたびに追記する短いログです。長い議事録にはしません。
 
+### 2026-04-29 - SSoT を CLAUDE.md に反転（AGENTS.md は wrapper 化）
+- What: 旧 AGENTS.md (54 行 SSoT) の内容を CLAUDE.md に移し SSoT 化、AGENTS.md は `@CLAUDE.md` のみを含む 5 行ラッパーへ縮約。`lib/__tests__/architecture/doc-size.test.ts` の上限を swap (CLAUDE ≤120 / AGENTS ≤30)。`docs/agent-onboarding.md` の構成図・責任表・触れていいファイル表・起動コマンド説明・アンチパターン記述を新構造に追従
+- Why: Claude Code は CLAUDE.md だけを auto-load する仕様。SSoT を AGENTS.md に置くと CLAUDE.md → `@AGENTS.md` を経由しないと正本に届かず、CLAUDE.md 単体では「何もわからない」leaf になっていた。本来 Claude Code の主要 entry が SSoT であるべきで、AGENTS.md は Codex 等の慣習 entry を SSoT に橋渡しする wrapper にする方が読み手フレンドリー
+- Rejected: 相互参照のまま維持(SSoT 候補が 2 つあり「どちらを編集すべきか」が曖昧。`@` 参照の経路として cleanであっても運用判断には不向き)、CLAUDE.md は短いまま AGENTS.md SSoT 維持(PR #50 spec 由来だが Claude 主導開発の auto-load 仕様と整合しない)
+- Next: harness-debt.md / harness-evidence.md などのメタ文書も将来「CLAUDE.md = SSoT」前提で記述する。新規ハーネス改善セッションでも CLAUDE.md を編集 target とする運用に切替
+- Decision: CLAUDE.md = SSoT、AGENTS.md = wrapper。一方向 reference (`AGENTS.md → @CLAUDE.md`)
+
 ### 2026-04-29 - ハーネス改善定期セッション(2 時間枠で 7 件実装)
 - What: 直近 30 日の git log / progress.md / PR 履歴から繰り返しミス 10 件を抽出し `harness-debt.md` 作成。決定論的 sensor を最優先に選択し、7 件を実装: arch test 3 種(`migration-uniqueness` / `doc-size`(AGENTS≤120, CLAUDE≤30) / `skill-size`(SKILL≤200, Procedure≤8 step))、`evals/runners/run-evals.ts` に dataset.tags ↔ criteria.md drift validation 追加、Stop hook に `scripts/check-forbidden-terms.sh`(CoffeeReview 識別子検出)、UserPromptSubmit hook に `scripts/detect-template-placeholder.sh`(`{{...}}` reminder 注入)、`pre-pr-self-review` SKILL に E2E getByText 警告ステップ追加。各対策について過去失敗を再現して捕捉確認 → `harness-evidence.md` に記録。AGENTS.md は 52 行 / 24 指示で 200 制限の遥か下のため refactor 不要
 - Why: ハーネスは「足し続ける」のではなく「腐敗を構造で防ぐ」のが本質。決定論的 sensor を最優先したのは ETH 研究の "lost in instructions" 含意で、AGENTS.md 行数を物理的に縛ることで「念のため指示」追加を不可能にする


### PR DESCRIPTION
## Summary

- Claude Code は **CLAUDE.md のみを auto-load** する仕様。SSoT を AGENTS.md に置いた旧設計（PR #50）では、CLAUDE.md は `@AGENTS.md` 経由でしか正本に届かず、単体では「何もわからない」leaf になっていた
- 反転して **CLAUDE.md = SSoT / AGENTS.md = wrapper** にし、各ツールの auto-load 起点が SSoT に直結するようにした
- **base branch**: `chore/harness-debt-session` (#54 の上に積む / PR スタック 9 段目)

## 反転前後

| | 旧 | 新 |
|---|---|---|
| CLAUDE.md | 10 行 / `@AGENTS.md` + Claude-specific | **63 行 / SSoT** |
| AGENTS.md | **54 行 / SSoT** | 5 行 / `@CLAUDE.md` のみ |
| arch test 上限 (CLAUDE / AGENTS) | 30 / 120 | **120 / 30**（swap） |

## 参照グラフ

```
        CLAUDE.md (SSoT)
        ↑
        │ @CLAUDE.md
        │
   AGENTS.md (wrapper)
```

| 起点 | 経路 |
|---|---|
| Claude Code | CLAUDE.md (auto) → 全部読む |
| Codex | AGENTS.md (auto) → @CLAUDE.md → 全部読む |

## なぜ反転したか

1. Claude Code の auto-load は CLAUDE.md。**主要 entry が SSoT であるべき**
2. 旧構造では Claude が `@AGENTS.md` を解決できないツールバージョンや状況で「project context が空」になりうるリスクがあった
3. 一方向 (`AGENTS.md → @CLAUDE.md`) にすることで「**どっちを編集すべきか**」が一意になる

## 却下案

- **相互参照維持** — `@` 参照グラフ的には clean だが、SSoT 候補が 2 つあり編集対象が曖昧
- **CLAUDE.md は短いまま AGENTS.md SSoT を維持（PR #50 のまま）** — Claude Code の auto-load 仕様と整合しない

## 連動更新

- `docs/agent-onboarding.md`: mermaid 図 / 責任表 / 触れていいファイル / 起動コマンド説明 / アンチパターン記述を新構造に追従
- `lib/__tests__/architecture/doc-size.test.ts`: 上限を swap (CLAUDE ≤120 / AGENTS ≤30)

## Test plan

- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint --quiet` → 警告なし
- [x] arch test → 59 pass (doc-size 含む)
- [x] CLAUDE.md (63 行) ≤ 120
- [x] AGENTS.md (5 行) ≤ 30

## マージ順序

1. #47 → main
2. #48 → main
3. #49 → main
4. #50 → main
5. #51 → main
6. #52 → main
7. #53 → main
8. #54 → main
9. **このPR** → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)