### PR TITLE
feat: Proactive Surfacing メタ disposition を Claude に embed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,12 @@ Helps enthusiasts track their coffee journey, discover patterns, and explore new
 1. Branch: `git checkout -b feature/name`
 2. spec-workflow MCP: Requirements → Design → Tasks → Implementation
 3. TDD: Test → Fail → Implement → Pass → Refactor (80%+ coverage)
-4. **Auto-PR**: タスク完了後は明示指示なしで commit → push → `gh pr create` まで自動実行する（destructive 操作・force push・main への直接 push は事前確認）。タスクごとに新規ブランチを切り、PR 本文には Summary / Test plan を含める
+4. **Proactive Surfacing**: 節目 (修正/機能追加/調査/リファクタ/完了報告後) で「他にやった方が良い follow-up は?」を自問する
+   - 既存ルール (Auto-PR 等) のスコープなら自動実行
+   - 未ルール化の案件は一行で確認 (`〜しますか?`)。1 ターン 1 提案
+   - ユーザー OK → 実行 **+ その場でルール化** (`feedback_<topic>.md` 作成 + `MEMORY.md` 索引追加 + Why に承認日記載)
+   - 候補カテゴリ: PR / E2E / docs / decision / progress.md / 隣接 cleanup / 同種問題調査 / 次ステップ scheduling
+5. **Auto-PR (昇格済みルール — 2026-04-29 承認)**: タスク完了後は明示指示なしで新規ブランチ作成 → commit → push → `gh pr create` まで自動実行。PR 本文に Summary / Test plan を含める。destructive 操作・force push・main への直接 push のみ事前確認
 
 ### Ubiquitous Language (MANDATORY)
 
@@ -80,4 +85,4 @@ Helps enthusiasts track their coffee journey, discover patterns, and explore new
 
 ---
 
-**Last Updated**: 2026-04-29 | **Version**: 1.3.0
+**Last Updated**: 2026-04-30 | **Version**: 1.4.0

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,6 +2,12 @@
 
 実装のたびに追記する短いログです。長い議事録にはしません。
 
+### 2026-04-30 - Proactive Surfacing メタ disposition を Claude に embed (気付き → 確認 → ルール昇格)
+- What: `~/.claude/projects/-Users-hotake-Documents-coffee-app-simple-coffee-collections/memory/feedback_proactive_surfacing.md` を新規作成し「節目で『他にやった方が良い follow-up は?』を自問 → 未ルール化案件は一行確認 → OK ならその場で `feedback_<topic>.md` 作成 + `MEMORY.md` 索引追記でルール昇格」というメタ disposition を embed。`MEMORY.md` の `## Workflow` セクションを 2 行構成 (メタ + Auto-PR 実例) に書き換え。`CLAUDE.md` の Feature Development Workflow に step 4 (Proactive Surfacing) と step 5 (Auto-PR 昇格済みルール) を追加。Last Updated/Version を 2026-04-30 / 1.4.0 に更新
+- Why: 旧 Auto-PR ルール (2026-04-29 確立、常に PR 自動作成) は具体例として正しかったが、ユーザー本意は PR 限定の自動化ではなく「follow-up 全般を能動提案 → OK ならルール化する disposition」だった。能動性 (Notice/Ask) と学習ループ (Promote) の組み合わせで「同じ確認を 2 度させない」を実現する
+- Rejected: Stop hook での機械的 nudge (judgement 必要なものは LLM 側で動かす方針)、旧 `feedback_auto_pr.md` の削除 (昇格済みルール実例として温存し、新 disposition から参照する構造)、Proactive Surfacing と Auto-PR の合流 (step 4 はメタ disposition、step 5 は具体ルールで層を分けた方が読みやすい)
+- Next: 効果が観察できなければ Stop hook で Edit/Write 直後限定の self-prompt nudge を追加検討。次タスク以降で Claude が他ジャンル (docs / E2E / 隣接 cleanup) の follow-up を能動提案するか、OK されたら新ルールが追加されるかを観察
+
 ### 2026-04-29 - ロード中／ロード後のレイアウト不一致を解消 (My Collection / Community / /coffee)
 - What: `app/(app)/coffee/_components/list/feed-skeleton.tsx` を新規作成し `FeedListSkeleton` / `SearchAndSortSkeleton` を export。`app/(app)/coffee/my/loading.tsx` と `app/(app)/coffee/community/loading.tsx` を新規追加し、page.tsx と同じ外側コンテナ (`max-w-6xl` → ヘッダー → SearchAndSort → `max-w-2xl` 縦フィード) を skeleton 化。`app/(app)/coffee/loading.tsx` を旧 3 列グリッドからリダイレクト先と一致する縦フィード skeleton に書き換え。Playwright で desktop/mobile の skeleton レンダリングを確認
 - Why: PR #46 で My Collection が 3 列グリッド → `max-w-2xl` 縦フィードに変わったが loading 表現が追従しておらず、`/coffee/my` と `/coffee/community` には loading.tsx 自体が無かった。`/coffee/loading.tsx` もリダイレクト先と全く異なるグリッドだったため、ロード中とロード後で UI がチラつく状態を解消

--- a/plans/rippling-percolating-sloth.md
+++ b/plans/rippling-percolating-sloth.md
@@ -1,97 +1,111 @@
-# ロード中／ロード後のレイアウト一致化
+# 能動的 follow-up 提案 + ルール昇格 disposition の組み込み
 
 ## Context
 
-`#46` (`feat: エディトリアルデザインシステム全体統一 & My Collection フィードレイアウト化`) で My Collection / Community が **3 列グリッド → 中央寄せの縦フィード (`max-w-2xl` の `FeedCard` リスト)** に変更されたが、loading 表現がそれに追従していないため、以下の不一致が発生している。
+ユーザー要望 (2026-04-30, 数回の course correction を経て確定):
 
-| ルート | 現在の loading | 実際の page | 問題 |
-|------|---------------|------------|------|
-| `/coffee/my` | **無し** | `max-w-6xl` 外側 → ヘッダー + `SearchAndSort` + `max-w-2xl` 縦フィード | ロード中は空白、ロード後にコンテンツが急にポップインする |
-| `/coffee/community` | **無し** | 同上 | 同上 |
-| `/coffee` | あり (3 列グリッド `max-w-6xl`) | `redirect()` のみ実体無し | リダイレクト先 (`/my` or `/community`) と全く違うグリッドが一瞬チラつく |
+> ただ言われたことをやるのでなく、この場面で他にやった方が良いことを自分で考えて『〜しますか?』と確認してほしい。聞いた上で OK と言われたものは、その場でルール化してほしい。例えば今回の PR 自動化はルール化して良い。
 
-ユーザー視点では「ロード中とロード後で UI が別物になる」体験になっており、これを揃える。
+つまり Claude に組み込みたいのは、単発の「能動提案」ではなく **学習ループ** :
 
-スコープ外: `/coffee/new` と `/coffee/[id]/edit` の loading.tsx に残るハードコード Tailwind 色 (`bg-amber-200`, `bg-neutral-200` 等) は **レイアウトはズレていない** ため今回は触らない（色トークン化は別タスクとして `memory-bank/progress.md` に Next として残す）。
+1. **Notice**: タスクの節目で「他にやった方が良い follow-up は?」を Claude 自身が自問
+2. **Ask**: ルール化されていない案件は一行で確認 (`〜しますか?`)
+3. **Promote**: ユーザーが OK したら、その場で実行する **だけでなく** メモリ/CLAUDE.md に新ルールとして書き足す → 次回以降は再確認なしで自動実行
+4. **Apply**: 既にルール化済みのものは re-ask しない
+
+過去経緯:
+- 旧「Auto-PR ルール (常に PR 自動作成)」は 2026-04-29 にユーザー明示指示で確立済み → これは **昇格済みルールの実例** として残す
+- 今回追加するのはその上位のメタ disposition: 「気付く → 聞く → 昇格させる」のループ自体
 
 ## 実装方針
 
-ロード後ビューの外側コンテナとカード構造を **そのまま 1:1 で複製** し、内部要素を `animate-pulse` のブロックに置換する。これによりレイアウトシフトをゼロにする。
+メモリ + CLAUDE.md の二層に **メタ disposition** を embed する。Stop hook 経由の機械的 nudge は今回は入れない (能動的気付きは LLM 側で動かすのが筋。効かなければ次タスクで検討)。
 
-### 1. `app/(app)/coffee/my/loading.tsx` を新規作成
+### 1. メモリ追加 (旧ファイル温存)
 
-`app/(app)/coffee/my/page.tsx:20-34` と `app/(app)/coffee/my/_components/view.tsx:30-58` を踏襲し、以下の構造で skeleton を作る:
+`~/.claude/projects/-Users-hotake-Documents-coffee-app-simple-coffee-collections/memory/feedback_auto_pr.md` は **削除しない** — 過去にユーザー承認で昇格された「ルール化済み follow-up」の実例として価値がある。これを参照しながら新 disposition がメタルールとして上に立つ構造にする。
+
+新規 `feedback_proactive_surfacing.md` を作成:
+
+- **rule (1 行)**: タスクの節目では Claude 自身が「他にやった方が良い follow-up は?」を自問する。ルール化されていない案件は実行前に一行で確認し、ユーザー OK なら **その場でルール化** (新メモリファイル作成 + `MEMORY.md` 索引追加) してから実行する
+- **Why**: 2026-04-30 ユーザー指示「ただ言われたことをやるでなく自分で考えて聞いてほしい / OK されたものはルール化してほしい」。能動性 + 学習ループの組み合わせで「同じ確認を 2 度させない」を実現
+- **How to apply** (3 段階で記載):
+  - **Step 1: 気付くべき節目**
+    - 修正完了後 / 機能追加後 / 調査・分析後 / リファクタ後 / 完了報告時
+  - **Step 2: 候補にする follow-up カテゴリ**
+    - PR 作成 / E2E テスト実行 / docs 更新 / decision 記録 / progress.md 追記 / 隣接 cleanup / 同種問題の調査 / 次ステップの scheduling
+    - 一行で `〜しますか?` 形式。複数候補なら 2-3 並べて選んでもらう
+  - **Step 3: 昇格手順**
+    - ユーザー OK → そのフォローアップ用の新メモリ `feedback_<topic>.md` を作成 (rule / Why / How to apply 構造)
+    - `MEMORY.md` の `## Workflow` セクションに 1 行索引を追加
+    - 完了 + 過去会話への直リンクとして「2026-MM-DD のユーザー指示で承認」を Why に記載
+- **例外条件**:
+  - ユーザーが「終わり」「とりあえずここまで」「もういい」と closure を示している時は提案しない
+  - 直前ターンで似た offer を出している時は重ねない (system prompt の don't-stack-offers を継承)
+  - 1 ターン 1 提案上限 (3 候補並列の選択肢提示は 1 提案として扱う)
+  - 既存ルール (例: Auto-PR) のスコープに収まる案件は再確認せず自動実行
+
+`~/.claude/projects/.../memory/MEMORY.md` の `## Workflow` セクションを以下に書き換え:
 
 ```
-section (mx-auto w-full max-w-6xl px-4 py-6 sm:py-10)
-├─ header div (mb-6 flex items-center justify-between)
-│   └─ タイトル skeleton (h-7 w-40) + 説明 skeleton (h-4 w-56)
-├─ SearchAndSort 風 box (mb-6)
-│   └─ rounded-sm border border-[var(--rule)] bg-[var(--paper)] p-4
-│       sm:flex-row レイアウトの中に検索入力風 (h-9 w-full sm:max-w-md) と並び順風 (h-9 w-32) の skeleton
-└─ Feed list (mx-auto flex max-w-2xl flex-col gap-6)
-    └─ FeedCard skeleton ×3
-        article: rounded-sm border border-[var(--rule)] bg-[var(--paper)] p-6
-        ├─ header: 日付/店名行 skeleton (h-3 w-32)
-        ├─ body grid (mt-4 gap-5 md:grid-cols-[1fr_200px] md:gap-6)
-        │   ├─ 左: 豆名 (h-7 w-3/4) + 焙煎度 (h-3 w-24) + ノート 4 行 (h-4 w-full ×4) + 軸チップ 4 個
-        │   └─ 右: RadarChart 円形 placeholder (h-[190px] w-[190px] rounded-full)
-        └─ footer: border-t border-[var(--rule-2)] pt-4 で TASTING SHEET ID と「シートを見る」風 skeleton
+## Workflow
+- [節目で能動的に follow-up を提案 → OK されたらルール化](feedback_proactive_surfacing.md) — メタ disposition (気付く → 聞く → 昇格)
+- [タスク完了後は自動で PR まで作成する](feedback_auto_pr.md) — 昇格済みルール実例 (2026-04-29 承認)
 ```
 
-カラー:
-- `bg-[var(--rule)]` (テキスト行用)
-- `bg-[var(--background-2)]` (大きいブロック用)
-- すべて `animate-pulse`
+### 2. CLAUDE.md 書き換え
 
-### 2. `app/(app)/coffee/community/loading.tsx` を新規作成
+`CLAUDE.md` の Feature Development Workflow を以下に変更:
 
-`app/(app)/coffee/community/page.tsx:19-34` と `feed-card.tsx:96-189` を踏襲。**My Collection との違いは FeedCard ヘッダーにユーザーアバター + display_name 行が出ること** のみ:
+```
+1. Branch: `git checkout -b feature/name`
+2. spec-workflow MCP: Requirements → Design → Tasks → Implementation
+3. TDD: Test → Fail → Implement → Pass → Refactor (80%+ coverage)
+4. **Proactive Surfacing**: 節目で「他にやった方が良い follow-up は?」を自問。
+   - 既存ルール (Auto-PR 等) のスコープなら自動実行
+   - 未ルール化の案件は一行で確認 (`〜しますか?`)
+   - ユーザー OK なら実行 **+ その場でルール化** (メモリ追加 + `MEMORY.md` 索引追記)
+5. **Auto-PR (昇格済みルール)**: タスク完了後は明示指示なしで commit → push → `gh pr create` まで自動実行。destructive 操作のみ事前確認
+```
 
-- header の `showUserHeader=true` 想定で、`h-9 w-9 rounded-full bg-[var(--espresso)]/30` のアバター skeleton + 名前行 (h-3 w-24) + 日付行 (h-3 w-32)
-- それ以外は `/coffee/my/loading.tsx` と同じ構造（タイトルだけ「コミュニティ」想定で同じ `h-7 w-40`）
+`Last Updated`: 2026-04-30 / `Version`: 1.4.0
 
-### 3. `app/(app)/coffee/loading.tsx` を更新
+### 3. progress.md 追記
 
-現在 (`max-w-6xl` の 3 列グリッド) はリダイレクト先のフィードと不一致。`/coffee/page.tsx:10-17` は `getCurrentUser()` の成否で `/coffee/my` または `/coffee/community` にリダイレクトするだけだが、サーバーリダイレクト前にこの loading が一瞬出る可能性がある。リダイレクト先と同じ縦フィード skeleton に書き換えて視覚的連続性を確保する。
-
-実装は `/coffee/community/loading.tsx` の中身をそのまま reuse できるよう、共通の `FeedListSkeleton` コンポーネントに切り出すことを検討。
-
-### 4. 共通化（推奨）
-
-`app/(app)/coffee/_components/list/` 配下に `feed-skeleton.tsx` を新規作成し、`<FeedListSkeleton showUserHeader={boolean} count={number} />` として 3 ヶ所の loading から呼ぶ。重複を防ぎ、将来 FeedCard が変わった時に追従しやすくなる。
-
-ファイル構成:
-- `app/(app)/coffee/_components/list/feed-skeleton.tsx` (新規)
-  - `FeedListSkeleton` (props: `showUserHeader`, `count`)
-  - 内部で `FeedCardSkeleton` を `count` 回レンダ
-- `app/(app)/coffee/_components/list/search-sort-skeleton.tsx` (新規) ※ヘッダー込みで切るかは実装時判断
-- 3 つの loading.tsx は外側 section + ヘッダー skeleton + `SearchAndSort` skeleton + `<FeedListSkeleton ... />` を組み合わせるだけにする
+CLAUDE.md の継続記録ルールに従い 1 エントリ:
+- What: メタ disposition (気付き → 確認 → 昇格) を memory + CLAUDE.md に embed
+- Why: 旧 Auto-PR ルールは具体例として正しかったが、ユーザー本意は「PR 限定の自動化ではなく、follow-up 全般を能動提案 → OK ならルール化する disposition」
+- Rejected: Stop hook での機械的 nudge (judgement 系は LLM で動かす方針)、旧 `feedback_auto_pr.md` の削除 (昇格済みルールの実例として温存)
+- Next: 効果が観察できなければ Stop hook で薄い self-prompt nudge を追加検討
 
 ## 変更ファイル
 
-| パス | 変更内容 |
-|------|---------|
-| `app/(app)/coffee/_components/list/feed-skeleton.tsx` | **新規** — `FeedListSkeleton`, `FeedCardSkeleton` を export |
-| `app/(app)/coffee/my/loading.tsx` | **新規** — page.tsx と同じ外側 + `FeedListSkeleton showUserHeader={false}` |
-| `app/(app)/coffee/community/loading.tsx` | **新規** — page.tsx と同じ外側 + `FeedListSkeleton showUserHeader={true}` |
-| `app/(app)/coffee/loading.tsx` | **書き換え** — リダイレクト先と一致する縦フィード skeleton に変更 |
+| ファイル | 変更 |
+|---------|------|
+| `~/.claude/projects/.../memory/feedback_proactive_surfacing.md` | **新規** — メタ disposition 本体 (Notice / Ask / Promote / Apply の 4 段階 + 例外) |
+| `~/.claude/projects/.../memory/feedback_auto_pr.md` | **そのまま温存** (昇格済みルール実例) |
+| `~/.claude/projects/.../memory/MEMORY.md` | `## Workflow` を 2 行構成 (メタ + 実例) に書き換え |
+| `CLAUDE.md` | Feature Development Workflow に step 4 (Proactive Surfacing) と step 5 (Auto-PR) を追加。Last Updated/Version 更新 |
+| `memory-bank/progress.md` | 1 エントリ追記 |
 
-## 既存の reuse 対象
+## 既存 reuse
 
-- `app/(app)/coffee/community/_components/feed-card.tsx:96-189` … FeedCard の DOM 構造（外側 article クラスや内側 grid 列幅 `md:grid-cols-[1fr_200px]`、RadarChart サイズ `190` 等）を skeleton にそのまま写経する真実のソース
-- `app/(app)/coffee/my/_components/view.tsx:46` および `app/(app)/coffee/community/_components/view.tsx:17` … 外側コンテナ `mx-auto flex max-w-2xl flex-col gap-6` のクラス
-- `app/(app)/coffee/_components/list/search-and-sort.tsx:67-97` … `SearchAndSort` の外側 box (`rounded-sm border border-[var(--rule)] bg-[var(--paper)] p-4 sm:flex-row sm:items-center sm:justify-between`) を skeleton で再現
-- `app/(app)/coffee/[id]/loading.tsx` … 同じプロジェクトでデザイントークンを使っている既存 loading のパターン（`bg-[var(--rule)]`, `bg-[var(--background-2)]`, `border-[var(--rule)]` の使い分け）
+- system prompt の「end your reply with a one-line offer to /schedule」パターン — /schedule 限定から汎用 follow-up + 学習ループへ拡張
+- 旧 `feedback_auto_pr.md` (CLAUDE.md からも参照) — 昇格済みルールの形式テンプレートとして再利用
+- `memory-bank/progress.md` 既存フォーマット (`What / Why / Rejected / Next / Decision`)
 
 ## 検証
 
-1. **型/Lint**: `npm run typecheck` / `npm run lint` が通る
-2. **ユニットテスト**: 既存の `community/__tests__/feed-card.test.tsx` 等は影響を受けないが、念のため `npm test -- --runInBand` を流す
-3. **目視確認 (最重要)**:
-   - dev server (`npm run dev`) を起動
-   - Chrome DevTools の Network タブで Slow 3G に絞り、`/coffee/my` と `/coffee/community` を開く
-   - **チェック**: ロード中の skeleton と、ロード後の実コンテンツの 1) 外側余白 2) コンテナ幅 (`max-w-6xl` / `max-w-2xl`) 3) `SearchAndSort` ボックスの位置 4) FeedCard のサイズ感 が一致しており、画面のガタつき (CLS) が起きないこと
-   - `/coffee` (リダイレクト元) を未ログイン状態と既ログイン状態で開き、リダイレクト前の一瞬に出る skeleton も縦フィードであること
-4. **モバイル**: 375px 幅でも `max-w-2xl` フィードの skeleton が画面幅にフィットしているか確認
-5. **記録**: 完了後 `memory-bank/progress.md` に CLAUDE.md の継続記録ルールに従い 1 エントリ追記。`Next:` に「`/coffee/new` と `/coffee/[id]/edit` の loading.tsx をデザイントークン化」を残す
+LLM disposition なので構造テストはない。dogfooding ベース:
+
+1. **文言レビュー**: 新メモリと CLAUDE.md を読み直し、「Notice → Ask → Promote → Apply」の 4 段階が一目で読み取れるか
+2. **メタテスト (本変更自体で実演)**: 本変更の実装完了後、Proactive Surfacing 原則に従い「PR 出しますか?」と一行確認 (= Auto-PR ルールに従い実際は自動実行する案件だが、ルールが昇格済みであることをユーザーに思い出してもらう意味で確認しても良い)。今回は **Auto-PR ルール適用で確認なし自動 PR** が正しい挙動
+3. **次タスク以降の observable behavior**: Claude が他のジャンルの follow-up (例: docs 更新, E2E 実行) を能動提案するか、OK されたら新ルールが追加されるか、を観察
+4. 効果薄なら `progress.md` Next: に「Stop hook で Edit/Write 直後限定の self-prompt nudge を追加」を残す
+
+## スコープ外
+
+- Stop hook での機械的 nudge — まずは disposition rule で運用
+- グローバルメモリ複製 — 本プロジェクト限定で開始
+- ルール昇格時の自動 git commit — メモリは user の auto-memory なのでリポジトリ commit は不要
+- 既存 Stop hook (`tsc --noEmit`, `lint --quiet`) には触らない


### PR DESCRIPTION
## Summary

- Claude に **「節目で follow-up を能動提案 → ユーザー OK ならその場でルール化」** という学習ループ disposition を embed する
- 旧 Auto-PR ルール (#56 で導入、2026-04-29 ユーザー承認) は **昇格済みルールの実例** として温存し、その上位のメタ disposition として今回の Proactive Surfacing が立つ二層構造
- これにより Claude が PR 作成だけでなく E2E 実行 / docs 更新 / decision 記録 / 隣接 cleanup / 同種問題調査 / 次ステップ scheduling など **未ルール化のフォローアップ全般** を能動的に拾い、承認されれば自動でルール昇格する

> **Note**: 本 PR は #56 (loading layout fix) を base にした stacked PR です。#56 マージ後に base を `main` に切り替えてください

## Disposition の動き

```
Notice → Ask → Promote → Apply
  ↓        ↓       ↓        ↓
節目で    一行で  feedback_  既存ルール
自問     確認     <topic>.md  はそのまま
                  新規作成    自動実行
                  + MEMORY.md
                  索引追加
```

## Changes

| ファイル | 変更 |
|---------|------|
| `CLAUDE.md` | Feature Development Workflow に step 4 (Proactive Surfacing) と step 5 (Auto-PR 昇格済みルール) を追加。Last Updated 2026-04-30 / Version 1.4.0 |
| `~/.claude/projects/.../memory/feedback_proactive_surfacing.md` | 新規 — rule / Why / Step 1 (節目) / Step 2 (カテゴリ) / Step 3 (昇格手順) / 例外 |
| `~/.claude/projects/.../memory/MEMORY.md` | Workflow セクションを 2 行構成 (メタ + 実例) に書き換え |
| `memory-bank/progress.md` | 2026-04-30 エントリ追記 |
| `plans/rippling-percolating-sloth.md` | 本タスクの実装計画に上書き |

(memory ファイルは user-level なのでリポジトリ commit には含まれない)

## 想定される動作変化

実装前:
```
User: 「ロード中／ロード後のレイアウト揃えて」
Claude: [実装] → [完了報告]
User: 「PR まで自動で出して」  ← ユーザーが言うまで PR に進まない
```

実装後:
```
User: 「ロード中／ロード後のレイアウト揃えて」
Claude: [実装] → [完了報告] → 「ついでに /coffee/new と /coffee/[id]/edit の
        loading.tsx もデザイントークン化しますか?」  ← 能動的に提案
User: 「やって」
Claude: [実行] + memory に feedback_design_token_followup.md を追加してルール化
```

## Test plan

- [x] CLAUDE.md / `feedback_proactive_surfacing.md` / `MEMORY.md` の文言を読み直し、Notice → Ask → Promote → Apply の 4 段階が一目で読み取れることを確認
- [x] Auto-PR (#56 で導入) と二層構造になり、矛盾しないことを確認
- [ ] **次タスク以降で observable behavior を観察** — Claude が他ジャンル (docs / E2E / 隣接 cleanup) の follow-up を能動提案するか、OK されたら新ルールが追加されるか
- [ ] 効果薄なら `progress.md` Next: に従い「Stop hook で Edit/Write 直後限定の self-prompt nudge」を別 PR で追加検討

## Notes

- 本 PR 自体が Auto-PR ルール (#56 由来) に従って自動作成されている
- スコープ外: Stop hook での機械的 nudge / グローバルメモリ複製 / ルール昇格時の自動 git commit (memory は user auto-memory のため repo commit 不要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)